### PR TITLE
Fixed top of a tooltip not being rendered

### DIFF
--- a/src/main/java/io/github/moehreag/tooltiptexture/mixin/TooltipRenderHelperMixin.java
+++ b/src/main/java/io/github/moehreag/tooltiptexture/mixin/TooltipRenderHelperMixin.java
@@ -80,7 +80,7 @@ public abstract class TooltipRenderHelperMixin {
 		outerBorder = drawStretchedTexture(graphics, TooltipTexture.BORDER_OUTER_RIGHT, x + width, y, z, 1, height) || outerBorder;
 
 		if (!outerBorder) {
-			renderHorizontalLine(graphics, x - 1, y, width, z, BACKGROUND_COLOR);
+			renderHorizontalLine(graphics, x, y - 1, width, z, BACKGROUND_COLOR);
 			renderHorizontalLine(graphics, x, y + height, width, z, BACKGROUND_COLOR);
 			renderVerticalLine(graphics, x - 1, y, height, z, BACKGROUND_COLOR);
 			renderVerticalLine(graphics, x + width, y, height, z, BACKGROUND_COLOR);


### PR DESCRIPTION
1.1.0 has a bug that causing top of a tooltip not render
![image](https://github.com/moehreag/TooltipTexture/assets/51480483/d71b81a7-1ec8-4a34-9954-67f609a063c6)
